### PR TITLE
commented out handling ReceiveEvent when updating vector clock in JsonWriter.cs

### DIFF
--- a/Src/PChecker/CheckerCore/Actors/Logging/JsonWriter.cs
+++ b/Src/PChecker/CheckerCore/Actors/Logging/JsonWriter.cs
@@ -253,7 +253,7 @@ namespace PChecker.Actors.Logging
                 // On dequeue OR receive event, has the string containing information about the current machine that dequeued (i.e. received the event),
                 // the event name, and payload. This is used to find the corresponding SendReqId from the machine that sent it in order to retrieve
                 // the vector clock of the sender machine during that time when it was sent.
-                case "ReceiveEvent":
+                // case "ReceiveEvent":
                 case "DequeueEvent":
                     var correspondingSendReqId = GetSendReceiveId(machine, logDetails.Event, logDetails.Payload);
                     var hashedGeneralCorrespondingSendReqId = HashString(correspondingSendReqId);


### PR DESCRIPTION
#### Issue

an `EnqueueEvent` can happen before a `ReceiveEvent` with PAvail, so when `JsonWriter.cs` attempts to look for the associated sender machine's vector clock to update vector clocks, it breaks because it can't find one (`OnEnqueueEvent` are not logged). 

#### Solution
Commented out updating vector clocks on `ReceiveEvent`s.